### PR TITLE
Replace `new(Thread)` with `&Thread{}`

### DIFF
--- a/starlark/allocation_test.go
+++ b/starlark/allocation_test.go
@@ -27,7 +27,7 @@ func TestDefaultAllocMaxIsUnbounded(t *testing.T) {
 }
 
 func TestCheckAllocs(t *testing.T) {
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(1000)
 
 	if err := thread.CheckAllocs(500); err != nil {
@@ -51,7 +51,7 @@ func TestCheckAllocs(t *testing.T) {
 
 func TestAllocDeclAndCheckBoundary(t *testing.T) {
 	const allocCap = 1000
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(allocCap)
 
 	if err := thread.CheckAllocs(allocCap); err != nil {
@@ -73,7 +73,7 @@ func TestAllocDeclAndCheckBoundary(t *testing.T) {
 func TestPositiveDeltaDeclaration(t *testing.T) {
 	const intendedAllocIncrease = 1000
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(0)
 
 	// Accept and correctly store reasonable size increase
@@ -95,7 +95,7 @@ func TestPositiveDeltaDeclarationExceedingMax(t *testing.T) {
 	const allocationIncrease = 1000
 	const maxAllocs = allocationIncrease / 2
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(maxAllocs)
 
 	// Error when too much memory is required
@@ -118,7 +118,7 @@ func TestOverflowingPositiveDeltaDeclaration(t *testing.T) {
 	const allocationIncrease = math.MaxInt64
 	const expectedErrMsg = "exceeded memory allocation limits"
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(0)
 
 	// Increase so that the next allocation will cause an overflow
@@ -149,7 +149,7 @@ func TestNegativeDeltaDeclaration(t *testing.T) {
 	const allocReduction = 100
 	const expectedFinalAllocs = allocGreatest - allocReduction
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(0)
 
 	if err := thread.AddAllocs(allocGreatest); err != nil {
@@ -168,7 +168,7 @@ func TestOverzealousNegativeDeltaDeclaration(t *testing.T) {
 	const allocReduction = 2 * allocGreatest
 	const expectedFinalAllocs = 0
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(0)
 
 	if err := thread.AddAllocs(allocGreatest); err != nil {
@@ -187,7 +187,7 @@ func TestConcurrentCheckAllocsUsage(t *testing.T) {
 	const maxAllocs = allocPeak + 1
 	const repetitions = 1_000_000
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(maxAllocs)
 	thread.AddAllocs(allocPeak - 1)
 
@@ -225,7 +225,7 @@ func TestConcurrentCheckAllocsUsage(t *testing.T) {
 func TestConcurrentAddAllocsUsage(t *testing.T) {
 	const expectedAllocs = 1_000_000
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.SetMaxAllocs(0)
 
 	done := make(chan struct{}, 2)
@@ -258,7 +258,7 @@ func TestCheckAllocsCancelledRejection(t *testing.T) {
 	const cancellationReason = "arbitrary cancellation reason"
 	const maxAllocs = 1000
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.Cancel(cancellationReason)
 	thread.SetMaxAllocs(maxAllocs)
 
@@ -273,7 +273,7 @@ func TestAddAllocsCancelledRejection(t *testing.T) {
 	const cancellationReason = "arbitrary cancellation reason"
 	const maxAllocs = 1000
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.Cancel(cancellationReason)
 	thread.SetMaxAllocs(maxAllocs)
 

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -999,7 +999,7 @@ func TestDeps(t *testing.T) {
 func TestThreadPermits(t *testing.T) {
 	const threadSafety = starlark.CPUSafe | starlark.MemSafe
 	t.Run("Safety=Allowed", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 
 		if !thread.Permits(starlark.Safe) {
@@ -1008,7 +1008,7 @@ func TestThreadPermits(t *testing.T) {
 	})
 
 	t.Run("Safety=Forbidden", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 
 		if thread.Permits(threadSafety &^ starlark.MemSafe) {
@@ -1017,7 +1017,7 @@ func TestThreadPermits(t *testing.T) {
 	})
 
 	t.Run("Safety=Invalid", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 
 		if thread.Permits(starlark.Safety(0xbad1091c) | threadSafety) {
@@ -1026,7 +1026,7 @@ func TestThreadPermits(t *testing.T) {
 	})
 
 	t.Run("ThreadSafety=Invalid", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		const invalidSafety = starlark.Safety(0xa19ae)
 		thread.RequireSafety(invalidSafety)
 
@@ -1043,7 +1043,7 @@ func TestThreadCheckPermits(t *testing.T) {
 	t.Run("Safety=Allowed", func(t *testing.T) {
 		const allowedSafety = threadSafety | starlark.IOSafe
 
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 
 		if err := thread.CheckPermits(allowedSafety); err != nil {
@@ -1054,7 +1054,7 @@ func TestThreadCheckPermits(t *testing.T) {
 	t.Run("Safety=Forbidden", func(t *testing.T) {
 		const forbiddenSafety = starlark.CPUSafe
 
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 
 		if err := thread.CheckPermits(forbiddenSafety); err == nil {
@@ -1069,7 +1069,7 @@ func TestThreadCheckPermits(t *testing.T) {
 	})
 
 	t.Run("Safety=Invalid", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		thread.RequireSafety(threadSafety)
 		const invalidSafety = starlark.Safety(0xbad1091c)
 
@@ -1081,7 +1081,7 @@ func TestThreadCheckPermits(t *testing.T) {
 	})
 
 	t.Run("ThreadSafety=Invalid", func(t *testing.T) {
-		thread := new(starlark.Thread)
+		thread := &starlark.Thread{}
 		const invalidSafety = starlark.Safety(0xa19ae)
 		thread.RequireSafety(invalidSafety)
 
@@ -1098,7 +1098,7 @@ func TestThreadRequireSafetyDoesNotUnsetFlags(t *testing.T) {
 	const newSafety = starlark.IOSafe | starlark.TimeSafe
 	const expectedSafety = initialSafety | newSafety
 
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.RequireSafety(initialSafety)
 	thread.RequireSafety(newSafety)
 

--- a/starlark/safety_test.go
+++ b/starlark/safety_test.go
@@ -138,7 +138,7 @@ def func():
 	pass
 func()
 `
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.RequireSafety(starlark.CPUSafe | starlark.MemSafe)
 
 	_, err := starlark.ExecFile(thread, "func_safety_test.go", prog, nil)
@@ -150,7 +150,7 @@ func()
 func TestLambdaSafeExecution(t *testing.T) {
 	// Ensure that lambdas can always be run
 	const prog = `(lambda x: x)(1)`
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.RequireSafety(starlark.CPUSafe | starlark.MemSafe)
 
 	_, err := starlark.ExecFile(thread, "lambda_safety_test.go", prog, nil)
@@ -160,7 +160,7 @@ func TestLambdaSafeExecution(t *testing.T) {
 }
 
 func TestBuiltinSafeExecution(t *testing.T) {
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.RequireSafety(starlark.CPUSafe | starlark.TimeSafe)
 
 	fn := starlark.NewBuiltin("fn", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
@@ -226,7 +226,7 @@ func (d *dummyCallable) Safety() starlark.Safety              { return d.safety 
 func (d *dummyCallable) DeclareSafety(safety starlark.Safety) { d.safety = safety }
 
 func TestCallableSafeExecution(t *testing.T) {
-	thread := new(starlark.Thread)
+	thread := &starlark.Thread{}
 	thread.RequireSafety(starlark.CPUSafe | starlark.MemSafe)
 	c := &dummyCallable{}
 	c.DeclareSafety(starlark.MemSafe)


### PR DESCRIPTION
Enforce consistent, concise style across Canonical's existing changes.