### PR TITLE
Memory tracking `any` builtin

### DIFF
--- a/starlark/allocation_test.go
+++ b/starlark/allocation_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/canonical/starlark/starlark"
-	"github.com/canonical/starlark/startest"
 )
 
 func TestDefaultAllocMaxIsUnbounded(t *testing.T) {
@@ -285,23 +284,4 @@ func TestAddAllocsCancelledRejection(t *testing.T) {
 	} else if allocs := thread.Allocs(); allocs != 0 {
 		t.Errorf("Changes were recorded against cancelled thread: expected 0 allocations, got %v", allocs)
 	}
-}
-
-func TestAnyAllocations(t *testing.T) {
-	st := startest.From(t)
-	st.SetMaxAllocs(0)
-	st.RunThread(func(thread *starlark.Thread) {
-		for i := 0; i < st.N; i++ {
-			args := starlark.Tuple{
-				starlark.NewList([]starlark.Value{
-					starlark.False, starlark.False, starlark.True,
-				}),
-			}
-			result, err := starlark.Call(thread, starlark.Universe["any"], args, nil)
-			if err != nil {
-				st.Error(err)
-			}
-			st.KeepAlive(result)
-		}
-	})
 }

--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/canonical/starlark/starlark"
+	"github.com/canonical/starlark/startest"
 )
 
 func TestUniverseSafeties(t *testing.T) {
@@ -67,6 +68,22 @@ func TestAbsAllocs(t *testing.T) {
 }
 
 func TestAnyAllocs(t *testing.T) {
+	st := startest.From(t)
+	st.SetMaxAllocs(0)
+	st.RunThread(func(thread *starlark.Thread) {
+		for i := 0; i < st.N; i++ {
+			args := starlark.Tuple{
+				starlark.NewList([]starlark.Value{
+					starlark.False, starlark.False, starlark.True,
+				}),
+			}
+			result, err := starlark.Call(thread, starlark.Universe["any"], args, nil)
+			if err != nil {
+				st.Error(err)
+			}
+			st.KeepAlive(result)
+		}
+	})
 }
 
 func TestAllAllocs(t *testing.T) {


### PR DESCRIPTION
Assert that Universe's `any` builtin makes no allocations.