### PR TITLE
Safety-aware iterators

### DIFF
--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -926,6 +926,8 @@ type repeatedFieldIterator struct {
 	i  int
 }
 
+var _ starlark.SafetyAware = &repeatedFieldIterator{}
+
 func (it *repeatedFieldIterator) Next(p *starlark.Value) bool {
 	if it.i < it.rf.Len() {
 		*p = it.rf.Index(it.i)
@@ -940,6 +942,8 @@ func (it *repeatedFieldIterator) Done() {
 		it.rf.itercount--
 	}
 }
+
+func (*repeatedFieldIterator) Safety() starlark.Safety { return starlark.NotSafe }
 
 func writeString(buf *bytes.Buffer, fdesc protoreflect.FieldDescriptor, v protoreflect.Value) {
 	// TODO(adonovan): opt: don't materialize the Starlark value.

--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -349,6 +349,8 @@ func (it *keyIterator) Done() {
 	}
 }
 
+func (*keyIterator) Safety() Safety { return NotSafe }
+
 // hashString computes the hash of s.
 func hashString(s string) uint32 {
 	if len(s) >= 12 {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1035,6 +1035,8 @@ func (it *rangeIterator) Next(p *Value) bool {
 }
 func (*rangeIterator) Done() {}
 
+func (*rangeIterator) Safety() Safety { return NotSafe }
+
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#repr
 func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
@@ -1610,6 +1612,8 @@ func (it *bytesIterator) Next(p *Value) bool {
 }
 
 func (*bytesIterator) Done() {}
+
+func (*bytesIterator) Safety() Safety { return NotSafe }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·count
 func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {

--- a/starlark/safety.go
+++ b/starlark/safety.go
@@ -92,6 +92,13 @@ type SafetyAware interface {
 var _ SafetyAware = Safety(0)
 var _ SafetyAware = new(Function)
 var _ SafetyAware = new(Builtin)
+var _ SafetyAware = new(rangeIterator)
+var _ SafetyAware = new(stringElemsIterator)
+var _ SafetyAware = new(stringCodepointsIterator)
+var _ SafetyAware = new(bytesIterator)
+var _ SafetyAware = new(listIterator)
+var _ SafetyAware = new(tupleIterator)
+var _ SafetyAware = new(keyIterator)
 
 func (set Safety) Safety() Safety { return set }
 

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -605,6 +605,8 @@ func (it *stringElemsIterator) Next(p *Value) bool {
 
 func (*stringElemsIterator) Done() {}
 
+func (*stringElemsIterator) Safety() Safety { return NotSafe }
+
 // A stringCodepoints is an iterable whose iterator yields a sequence of
 // Unicode code points, either numerically or as successive substrings.
 // It is not indexable.
@@ -653,6 +655,8 @@ func (it *stringCodepointsIterator) Next(p *Value) bool {
 }
 
 func (*stringCodepointsIterator) Done() {}
+
+func (*stringCodepointsIterator) Safety() Safety { return NotSafe }
 
 // A Function is a function defined by a Starlark def statement or lambda expression.
 // The initialization behavior of a Starlark module is also represented by a Function.
@@ -965,6 +969,8 @@ func (it *listIterator) Done() {
 	}
 }
 
+func (*listIterator) Safety() Safety { return NotSafe }
+
 func (l *List) SetIndex(i int, v Value) error {
 	if err := l.checkMutable("assign to element of"); err != nil {
 		return err
@@ -1052,6 +1058,8 @@ func (it *tupleIterator) Next(p *Value) bool {
 }
 
 func (it *tupleIterator) Done() {}
+
+func (*tupleIterator) Safety() Safety { return NotSafe }
 
 // A Set represents a Starlark set value.
 // The zero value of Set is a valid empty set.


### PR DESCRIPTION
Iterators allow execution of arbitrary code within builtins. Therefore, for a builtin to be safe, it must be able to assert that the required safety is upheld.
