### PR TITLE
Allow iterators to declare allocations

### DIFF
--- a/starlark/value.go
+++ b/starlark/value.go
@@ -268,7 +268,8 @@ type Iterator interface {
 type SafeIterator interface {
 	SafetyAware
 	// If the iterator is exhausted, Next returns (false, nil). If the iterator
-	// errored, it returns (false, err), otherwise it sets *p to the current element of the sequence, advances the iterator and returns (true, nil)
+	// errored, it returns (false, err), otherwise it sets *p to the current
+	// element of the sequence, advances the iterator and returns (true, nil)
 	SafeNext(thread *Thread, p *Value) (bool, error)
 	SafeDone(thread *Thread) error
 }


### PR DESCRIPTION
Iterators may make allocations as they run. Many builtins in Universe take and run iterators, hence their memory-safety is dependent on that of an iterator.
