### PR TITLE
Fix concurrent `CheckExecutionSteps` test on 32-bit systems

### DIFF
--- a/starlark/export_test.go
+++ b/starlark/export_test.go
@@ -5,6 +5,9 @@ func ThreadSafety(thread *Thread) Safety {
 }
 
 func (thread *Thread) SubtractExecutionSteps(delta uint64) {
+	thread.stepsLock.Lock()
+	defer thread.stepsLock.Unlock()
+
 	thread.steps -= delta
 }
 


### PR DESCRIPTION
When run on 32-bit systems the `CheckExecutionSteps` concurrent usage test would occasionally fail as the `SubtractExecutionSteps` method added for testing was not thread-safe.
