### PR TITLE
Fix repeated calls to `Run{Thread,String}` not executing

### DIFF
--- a/startest/startest.go
+++ b/startest/startest.go
@@ -219,7 +219,7 @@ func (st *ST) RunString(code string) (ok bool) {
 	if codeErr != nil {
 		st.Error(codeErr)
 	}
-	return codeErr == nil
+	return !st.abortLoop && codeErr == nil
 }
 
 // RunThread tests a function which has access to a Starlark thread.

--- a/startest/startest.go
+++ b/startest/startest.go
@@ -342,12 +342,11 @@ func (st *ST) measureExecution(thread *starlark.Thread, fn func(*starlark.Thread
 		beforeAllocs := readMemoryUsage(st.requiredSafety.Contains(starlark.MemSafe))
 		fn(thread)
 		afterAllocs := readMemoryUsage(st.requiredSafety.Contains(starlark.MemSafe))
-
-		runtime.KeepAlive(alive)
-
 		if st.runFailed {
 			return runStats{}, false
 		}
+
+		runtime.KeepAlive(alive)
 
 		// If st.alive was reallocated, the cost of its new memory block is
 		// included in the measurement. This overhead must be discounted

--- a/startest/startest.go
+++ b/startest/startest.go
@@ -102,10 +102,6 @@ func (st *ST) Errorf(format string, args ...interface{}) {
 	st.runFailed = true
 }
 
-func (st *ST) Failed() bool {
-	return st.runFailed || st.TestBase.Failed()
-}
-
 // SetMaxAllocs optionally sets the max allocations allowed per unit of st.N.
 func (st *ST) SetMaxAllocs(maxAllocs uint64) {
 	st.maxAllocs = maxAllocs

--- a/startest/startest_test.go
+++ b/startest/startest_test.go
@@ -329,7 +329,7 @@ func TestFailed(t *testing.T) {
 	}
 }
 
-func TestMultiUse(t *testing.T) {
+func TestMultipleRunCalls(t *testing.T) {
 	t.Run("method=RunThread", func(t *testing.T) {
 		var executed bool
 

--- a/startest/startest_test.go
+++ b/startest/startest_test.go
@@ -335,7 +335,7 @@ func TestMultipleRunCalls(t *testing.T) {
 
 		dummy := &dummyBase{}
 		st := startest.From(dummy)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 2; i++ {
 			executed = false
 			st.RunThread(func(*starlark.Thread) {
 				executed = true
@@ -358,7 +358,7 @@ func TestMultipleRunCalls(t *testing.T) {
 		dummy := &dummyBase{}
 		st := startest.From(dummy)
 		st.AddBuiltin(fn)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 2; i++ {
 			fnCalled = false
 			if ok := st.RunString(`fn()`); ok {
 				t.Errorf("RunString returned true on iteration with i=%d", i)

--- a/startest/startest_test.go
+++ b/startest/startest_test.go
@@ -690,8 +690,8 @@ func TestRunStringError(t *testing.T) {
 		dummy := &dummyBase{}
 		st := startest.From(dummy)
 		ok := st.RunString(fmt.Sprintf("st.error(%s)", test.src))
-		if !ok {
-			t.Errorf("%s: RunString returned false", test.name)
+		if ok {
+			t.Errorf("%s: RunString returned true", test.name)
 		}
 		if !st.Failed() {
 			t.Errorf("%s: expected failure", test.name)
@@ -957,8 +957,8 @@ func TestRunStringMemSafety(t *testing.T) {
 			for _ in st.ntimes():
 				st.keep_alive(overallocate())
 		`)
-		if !ok {
-			t.Errorf("RunString returned false")
+		if ok {
+			t.Errorf("RunString returned true")
 		}
 
 		if !st.Failed() {
@@ -1064,8 +1064,8 @@ func TestAssertModuleIntegration(t *testing.T) {
 			st := startest.From(dummy)
 			st.RequireSafety(starlark.MemSafe) // TODO: remove this once full safety reached
 			st.AddBuiltin(no_error)
-			if ok := st.RunString(test.input); !ok {
-				t.Errorf("%s: RunString returned false on '%s'", test.name, test.input)
+			if ok := st.RunString(test.input); ok {
+				t.Errorf("%s: RunString returned true on '%s'", test.name, test.input)
 			}
 
 			if !st.Failed() {


### PR DESCRIPTION
Fixes a bug which prevents `RunThread` and `RunString` from running after an earlier contains test-errors.
