### PR TITLE
Make receiver usage consistent

### DIFF
--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -952,7 +952,7 @@ func (it *repeatedFieldIterator) Done() {
 	}
 }
 
-func (*repeatedFieldIterator) Safety() starlark.Safety { return starlark.NotSafe }
+func (it *repeatedFieldIterator) Safety() starlark.Safety { return starlark.NotSafe }
 
 func writeString(buf *bytes.Buffer, fdesc protoreflect.FieldDescriptor, v protoreflect.Value) {
 	// TODO(adonovan): opt: don't materialize the Starlark value.
@@ -1168,7 +1168,7 @@ func (e EnumDescriptor) CallInternal(_ *starlark.Thread, args starlark.Tuple, kw
 	}
 	return EnumValueDescriptor{Desc: v}, nil
 }
-func (EnumDescriptor) Safety() starlark.Safety { return starlark.NotSafe }
+func (e EnumDescriptor) Safety() starlark.Safety { return starlark.NotSafe }
 
 // enumValueOf converts an int, string, or enum value to a value of the specified enum type.
 func enumValueOf(enum protoreflect.EnumDescriptor, x starlark.Value) (protoreflect.EnumValueDescriptor, error) {

--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -349,7 +349,7 @@ func (it *keyIterator) Done() {
 	}
 }
 
-func (*keyIterator) Safety() Safety { return NotSafe }
+func (ki *keyIterator) Safety() Safety { return NotSafe }
 
 // hashString computes the hash of s.
 func hashString(s string) uint32 {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1079,7 +1079,7 @@ func (it *rangeIterator) Next(p *Value) bool {
 }
 func (*rangeIterator) Done() {}
 
-func (*rangeIterator) Safety() Safety { return NotSafe }
+func (it *rangeIterator) Safety() Safety { return NotSafe }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#repr
 func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
@@ -1657,7 +1657,7 @@ func (it *bytesIterator) Next(p *Value) bool {
 
 func (*bytesIterator) Done() {}
 
-func (*bytesIterator) Safety() Safety { return NotSafe }
+func (it *bytesIterator) Safety() Safety { return NotSafe }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·count
 func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {

--- a/starlark/safety.go
+++ b/starlark/safety.go
@@ -76,8 +76,8 @@ func (flags Safety) String() string {
 
 // CheckValid checks that a given set of safety flags contains only defined
 // flags.
-func (f Safety) CheckValid() error {
-	if f >= safetyFlagsLimit {
+func (flags Safety) CheckValid() error {
+	if flags >= safetyFlagsLimit {
 		return errors.New("internal error: invalid safety flags")
 	}
 	return nil
@@ -111,7 +111,7 @@ type SafetyError struct {
 	Missing Safety
 }
 
-func (SafetyError) Error() string {
+func (se SafetyError) Error() string {
 	return "feature unavailable to the sandbox"
 }
 

--- a/starlark/safety_test.go
+++ b/starlark/safety_test.go
@@ -213,17 +213,17 @@ var (
 	_ starlark.SafetyAware = &dummyCallable{}
 )
 
-func (dummyCallable) String() string        { return "" }
-func (dummyCallable) Type() string          { return "dummyCallable" }
-func (dummyCallable) Freeze()               {}
-func (dummyCallable) Truth() starlark.Bool  { return false }
-func (dummyCallable) Hash() (uint32, error) { return 0, nil }
-func (dummyCallable) Name() string          { return "dummyCallable" }
-func (dummyCallable) CallInternal(*starlark.Thread, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+func (dc dummyCallable) String() string        { return "" }
+func (dc dummyCallable) Type() string          { return "dummyCallable" }
+func (dc dummyCallable) Freeze()               {}
+func (dc dummyCallable) Truth() starlark.Bool  { return false }
+func (dc dummyCallable) Hash() (uint32, error) { return 0, nil }
+func (dc dummyCallable) Name() string          { return "dummyCallable" }
+func (dc dummyCallable) CallInternal(*starlark.Thread, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
 	return starlark.None, nil
 }
-func (d *dummyCallable) Safety() starlark.Safety              { return d.safety }
-func (d *dummyCallable) DeclareSafety(safety starlark.Safety) { d.safety = safety }
+func (dc *dummyCallable) Safety() starlark.Safety              { return dc.safety }
+func (dc *dummyCallable) DeclareSafety(safety starlark.Safety) { dc.safety = safety }
 
 func TestCallableSafeExecution(t *testing.T) {
 	thread := &starlark.Thread{}

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -605,7 +605,7 @@ func (it *stringElemsIterator) Next(p *Value) bool {
 
 func (*stringElemsIterator) Done() {}
 
-func (*stringElemsIterator) Safety() Safety { return NotSafe }
+func (it *stringElemsIterator) Safety() Safety { return NotSafe }
 
 // A stringCodepoints is an iterable whose iterator yields a sequence of
 // Unicode code points, either numerically or as successive substrings.
@@ -656,7 +656,7 @@ func (it *stringCodepointsIterator) Next(p *Value) bool {
 
 func (*stringCodepointsIterator) Done() {}
 
-func (*stringCodepointsIterator) Safety() Safety { return NotSafe }
+func (it *stringCodepointsIterator) Safety() Safety { return NotSafe }
 
 // A Function is a function defined by a Starlark def statement or lambda expression.
 // The initialization behavior of a Starlark module is also represented by a Function.
@@ -969,7 +969,7 @@ func (it *listIterator) Done() {
 	}
 }
 
-func (*listIterator) Safety() Safety { return NotSafe }
+func (it *listIterator) Safety() Safety { return NotSafe }
 
 func (l *List) SetIndex(i int, v Value) error {
 	if err := l.checkMutable("assign to element of"); err != nil {
@@ -1059,7 +1059,7 @@ func (it *tupleIterator) Next(p *Value) bool {
 
 func (it *tupleIterator) Done() {}
 
-func (*tupleIterator) Safety() Safety { return NotSafe }
+func (it *tupleIterator) Safety() Safety { return NotSafe }
 
 // A Set represents a Starlark set value.
 // The zero value of Set is a valid empty set.

--- a/startest/startest.go
+++ b/startest/startest.go
@@ -295,7 +295,7 @@ func (st *ST) Attr(name string) (starlark.Value, error) {
 	return nil, nil
 }
 
-func (*ST) AttrNames() []string {
+func (st *ST) AttrNames() []string {
 	return []string{
 		"error",
 		"fatal",

--- a/startest/startest_test.go
+++ b/startest/startest_test.go
@@ -784,11 +784,11 @@ var _ starlark.Value = &dummyRange{}
 var _ starlark.Iterable = &dummyRange{}
 var _ starlark.Iterator = &dummyRangeIterator{}
 
-func (*dummyRange) String() string                { return "dummyRange" }
-func (*dummyRange) Type() string                  { return "dummyRange" }
-func (*dummyRange) Freeze()                       {}
-func (*dummyRange) Truth() starlark.Bool          { return starlark.True }
-func (*dummyRange) Hash() (uint32, error)         { return 0, errors.New("unhashable type: dummyRange") }
+func (dr *dummyRange) String() string             { return "dummyRange" }
+func (dr *dummyRange) Type() string               { return "dummyRange" }
+func (dr *dummyRange) Freeze()                    {}
+func (dr *dummyRange) Truth() starlark.Bool       { return starlark.True }
+func (dr *dummyRange) Hash() (uint32, error)      { return 0, errors.New("unhashable type: dummyRange") }
 func (dr *dummyRange) Iterate() starlark.Iterator { return &dummyRangeIterator{0, *dr} }
 
 func (iter *dummyRangeIterator) Next(p *starlark.Value) bool {


### PR DESCRIPTION
Some receivers were omitted; this PR includes them in Canonical’s patch regardless of whether they are used.
