### PR TITLE
Ignore struct field indirect size by tag

### DIFF
--- a/starlark/estimatesize.go
+++ b/starlark/estimatesize.go
@@ -298,7 +298,7 @@ func estimateStructIndirect(v reflect.Value, seen map[uintptr]struct{}) uintptr 
 	result := uintptr(0)
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {
-		if hasTag(typ.Field(i), "starlark", "ignore-indirect-size") {
+		if hasTag(typ.Field(i), "size", "extern") {
 			continue
 		}
 

--- a/starlark/estimatesize_test.go
+++ b/starlark/estimatesize_test.go
@@ -337,7 +337,7 @@ func TestEstimateTaggedStruct(t *testing.T) {
 	st.RunThread(func(thread *starlark.Thread) {
 		value := struct {
 			counted string
-			ignored string `starlark:"XXX,ignore-indirect-size,XXX"`
+			ignored string `size:"XXX,extern,XXX"`
 		}{
 			counted: strings.Repeat("Hello, World!", st.N),
 			ignored: strings.Repeat("Hello, World!", st.N),


### PR DESCRIPTION
Currently, if `EstimateSize` estimates the size of a `struct` it will recursively count the size of all fields. This PR allows struct fields to be tagged to be skipped when estimating size.
