### PR TITLE
Provide values for common sizes

### DIFF
--- a/starlark/estimatesize.go
+++ b/starlark/estimatesize.go
@@ -34,6 +34,10 @@ import (
 // EstimateSizeShallow has been removed for now since there was no agreement of how
 // to make it consistent.
 
+var InterfaceSize = RoundAllocSize(int64(unsafe.Sizeof(interface{}(nil))))
+var StringHeaderSize = RoundAllocSize(int64(unsafe.Sizeof(reflect.StringHeader{})))
+var SliceHeaderSize = RoundAllocSize(int64(unsafe.Sizeof(reflect.SliceHeader{})))
+
 // EstimateSize returns the estimated size of the
 // value pointed by obj, taking into account the whole
 // object tree.


### PR DESCRIPTION
To avoid arcane use of `EstimateSize` for common tasks, this PR provides some useful values which frequently come up in size estimation but which aren’t pretty to express.

This PR exposes three new values: `InterfaceSize`, `StringHeaderSize` and `SliceHeaderSize`. These are as follows.
```go
// InterfaceSize solves:
iface := interface{}(nil)
InterfaceSize == EstimateSize(&iface) // Strange ‘&‘
InterfaceSize == RoundAllocSize(int64(unsafe.Sizeof(interface{}(nil)))) // encourages use of unsafe

// StringHeaderSize solves:
StringHeaderSize == RoundAllocSize(int64(unsafe.Sizeof(reflect.StringHeader{})))

// SliceHeaderSize solves:
SliceHeaderSize == EstimateSize([]T{})
SliceHeaderSize == RoundAllocSize(int64(unsafe.Sizeof(reflect.SliceHeader{})))
```
