### PR TITLE
Estimate `make` size

### DIFF
--- a/starlark/estimatesize.go
+++ b/starlark/estimatesize.go
@@ -72,7 +72,7 @@ func EstimateMakeSize(template interface{}, n int) int64 {
 	}
 }
 
-const templateTooLong = "template length must be at most 1: got value of length %d"
+const templateTooLong = "template length must be at most 1: got length %d"
 
 func estimateMakeSliceSize(template reflect.Value, n int) uintptr {
 	len := template.Len()

--- a/starlark/estimatesize_test.go
+++ b/starlark/estimatesize_test.go
@@ -515,18 +515,18 @@ func TestEstimateMakeSize(t *testing.T) {
 			template: 0.0,
 		}, {
 			name:     "slice",
-			expect:   "template length must be at most 1: got value of length 2",
+			expect:   "template length must be at most 1: got length 2",
 			template: []string{"spanner", "wrench"},
 		}, {
 			name:   "map",
-			expect: "template length must be at most 1: got value of length 2",
+			expect: "template length must be at most 1: got length 2",
 			template: map[string]float64{
 				"pi":  math.Pi,
 				"phi": math.Phi,
 			},
 		}, {
 			name:   "chan",
-			expect: "template length must be at most 1: got value of length 3",
+			expect: "template length must be at most 1: got length 3",
 			template: func() interface{} {
 				ret := make(chan int, 3)
 				ret <- 1


### PR DESCRIPTION
This PR adds a function to estimate the cost of constructing objects with `make`. This should help avoid the need to explicitly count interface sizes as these can be encoded in the passed ‘template’ object.
