### PR TITLE
Add safety dependency between test iterators and `BindThread`

### DIFF
--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -104,7 +104,12 @@ type testIterator struct {
 var _ starlark.SafeIterator = &testIterator{}
 
 func (it *testIterator) BindThread(thread *starlark.Thread) { it.thread = thread }
-func (it *testIterator) Safety() starlark.Safety            { return starlark.Safe }
+func (it *testIterator) Safety() starlark.Safety {
+	if it.thread == nil {
+		return starlark.NotSafe
+	}
+	return starlark.Safe
+}
 func (it *testIterator) Next(p *starlark.Value) bool {
 	it.n++
 	if it.nth == nil {
@@ -1187,7 +1192,12 @@ var _ starlark.SafeIterator = &allocatingIterator{}
 func (it *allocatingIterator) Done()                              {}
 func (it *allocatingIterator) BindThread(thread *starlark.Thread) { it.thread = thread }
 func (it *allocatingIterator) Err() error                         { return it.err }
-func (it *allocatingIterator) Safety() starlark.Safety            { return starlark.MemSafe }
+func (it *allocatingIterator) Safety() starlark.Safety {
+	if it.thread == nil {
+		return starlark.NotSafe
+	}
+	return starlark.MemSafe
+}
 
 func (it *allocatingIterator) Next(p *starlark.Value) bool {
 	list := starlark.NewList(make([]starlark.Value, 0, it.size))

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -1576,12 +1576,11 @@ func SafeIterate(thread *Thread, x Value) (Iterator, error) {
 
 		if thread != nil {
 			if safeIter, ok := iter.(SafeIterator); ok {
+				safeIter.BindThread(thread)
+
 				if err := thread.CheckPermits(safeIter); err != nil {
 					return nil, err
 				}
-
-				safeIter.BindThread(thread)
-
 				return safeIter, nil
 			} else if err := thread.CheckPermits(NotSafe); err != nil {
 				return nil, err


### PR DESCRIPTION
The test iterators are not `MemSafe` unless they have been bound to a thread (otherwise their memory usage is not checked against any bound and hence they are not `MemSafe`!). Although these test iterators are never called without `BindThread` having implicitly been called by `SafeIterate`, explicitly adding the dependency on `BindThread` sets a good example.
