### PR TITLE
Add overheads for Go types

### DIFF
--- a/starlark/estimatesize.go
+++ b/starlark/estimatesize.go
@@ -35,6 +35,11 @@ import (
 // EstimateSizeShallow has been removed for now since there was no agreement of how
 // to make it consistent.
 
+var StringTypeOverhead = EstimateSize("")
+var SliceTypeOverhead = EstimateSize([]struct{}{})
+var MapTypeOverhead = EstimateSize(map[struct{}]struct{}{})
+var ChanTypeOverhead = EstimateSize(make(chan struct{}))
+
 // EstimateSize returns the estimated size of the
 // value pointed by obj, taking into account the whole
 // object tree.

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -550,8 +550,6 @@ func (f Float) Unary(op syntax.Token) (Value, error) {
 // of a Starlark string as a Go string.
 type String string
 
-var StringTypeOverhead = EstimateSize(String(""))
-
 func (s String) String() string        { return syntax.Quote(string(s), false) }
 func (s String) GoString() string      { return string(s) }
 func (s String) Type() string          { return "string" }


### PR DESCRIPTION
This PR adds `*TypeOverhead` constants for `slice`, `map` and `chan` types
