### PR TITLE
Enforce consistent `Fatal` and `Fatalf` usage in tests

### DIFF
--- a/lib/time/time_test.go
+++ b/lib/time/time_test.go
@@ -44,8 +44,7 @@ func TestMethodSafetiesExist(t *testing.T) {
 func TestTimeFromTimestampAllocs(t *testing.T) {
 	from_timestamp, ok := time.Module.Members["from_timestamp"]
 	if !ok {
-		t.Error("no such builtin: time.from_timestamp")
-		return
+		t.Fatalf("no such builtin: time.from_timestamp")
 	}
 
 	st := startest.From(t)
@@ -64,8 +63,7 @@ func TestTimeFromTimestampAllocs(t *testing.T) {
 func TestTimeIsValidTimezoneAllocs(t *testing.T) {
 	is_valid_timezone, ok := time.Module.Members["is_valid_timezone"]
 	if !ok {
-		t.Error("no such builtin: time.is_valid_timezone")
-		return
+		t.Fatalf("no such builtin: time.is_valid_timezone")
 	}
 
 	t.Run("timezone=valid", func(t *testing.T) {
@@ -105,8 +103,7 @@ func TestTimeNowAllocs(t *testing.T) {
 func TestTimeParseDurationAllocs(t *testing.T) {
 	parse_duration, ok := time.Module.Members["parse_duration"]
 	if !ok {
-		t.Errorf("no such builtin: parse_duration")
-		return
+		t.Fatalf("no such builtin: parse_duration")
 	}
 
 	t.Run("arg=duration", func(t *testing.T) {

--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -1684,8 +1684,7 @@ func TestStringCapitalizeAllocs(t *testing.T) {
 func testStringIterable(t *testing.T, methodName string) {
 	method, _ := starlark.String("arbitrary-string").Attr(methodName)
 	if method == nil {
-		t.Errorf("no such method: string.%s", methodName)
-		return
+		t.Fatalf("no such method: string.%s", methodName)
 	}
 
 	st := startest.From(t)
@@ -1743,8 +1742,7 @@ func TestStringElemsAllocs(t *testing.T) {
 func testStringFixAllocs(t *testing.T, method_name string) {
 	method, _ := starlark.String("foo-bar-foo").Attr(method_name)
 	if method == nil {
-		t.Errorf("no such method: %s", method)
-		return
+		t.Fatalf("no such method: %s", method)
 	}
 
 	st := startest.From(t)
@@ -2105,8 +2103,7 @@ func TestStringLowerAllocs(t *testing.T) {
 func testStringStripAllocs(t *testing.T, method_name string) {
 	method, _ := starlark.String("     ababaZZZZZababa     ").Attr(method_name)
 	if method == nil {
-		t.Errorf("no such method: string.%s", method_name)
-		return
+		t.Fatalf("no such method: string.%s", method_name)
 	}
 
 	t.Run("with-cutset=no", func(t *testing.T) {


### PR DESCRIPTION
This PR refactors some older code which used the pattern
```go
builtin, ok := Universe["foo"]
if !ok {
    t.Error("no such builtin: foo")
    return
}
```
Replacing it with the cleaner
```go
builtin, ok := Universe["foo"]
if !ok {
    t.Fatal("no such builtin: foo")
}
```
