### PR TITLE
Add `CheckSafety` helper function

### DIFF
--- a/starlark/safety.go
+++ b/starlark/safety.go
@@ -128,7 +128,7 @@ func (set Safety) CheckContains(subset Safety) error {
 // sufficient safety for the given thread. CheckSafety allows a nil thread.
 func CheckSafety(thread *Thread, value interface{}) error {
 	if isInvalidNil(value) {
-		return errors.New("cannot check safety of an invalid nil value")
+		return errors.New("cannot check safety of invalid nil value")
 	}
 	if thread == nil {
 		return nil // A nil thread makes no safety requirements.

--- a/starlark/safety_test.go
+++ b/starlark/safety_test.go
@@ -323,32 +323,32 @@ func TestCheckSafety(t *testing.T) {
 	}, {
 		name:   "nil-interface",
 		thread: &starlark.Thread{},
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil.ptr",
 		thread: &starlark.Thread{},
 		value:  (*dummySafetyAware)(nil),
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil-map",
 		thread: &starlark.Thread{},
 		value:  (map[int]int)(nil),
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil-chan",
 		thread: &starlark.Thread{},
 		value:  (chan int)(nil),
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil-unsafe-pointer",
 		thread: &starlark.Thread{},
 		value:  (unsafe.Pointer)(nil),
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil-func",
 		thread: &starlark.Thread{},
 		value:  (func())(nil),
-		expect: "cannot check safety of nil value",
+		expect: "cannot check safety of invalid nil value",
 	}, {
 		name:   "nil-slice",
 		thread: &starlark.Thread{},


### PR DESCRIPTION
Before executing potentially-unsafe code, safety flags must be checked in order to uphold the contract between a thread (which requires some safety) and code (which has a set of safeties considered whilst developing it).

This PR adds a new helper function to simplify these flag checks, transparently handling:
- `SafetyAware` values,
- non-`SafetyAware` values and
- an absent (`nil`) `Thread`
