### PR TITLE
Fixing `parse_duration` tests

### DIFF
--- a/lib/time/time_test.go
+++ b/lib/time/time_test.go
@@ -109,13 +109,14 @@ func TestTimeParseDurationAllocs(t *testing.T) {
 	t.Run("arg=duration", func(t *testing.T) {
 		st := startest.From(t)
 		st.RequireSafety(starlark.MemSafe)
-		st.SetMaxAllocs(0)
 		st.RunThread(func(thread *starlark.Thread) {
-			result, err := starlark.Call(thread, parse_duration, starlark.Tuple{time.Duration(10)}, nil)
-			if err != nil {
-				t.Error(err)
+			for i := 0; i < st.N; i++ {
+				result, err := starlark.Call(thread, parse_duration, starlark.Tuple{time.Duration(10)}, nil)
+				if err != nil {
+					t.Error(err)
+				}
+				st.KeepAlive(result)
 			}
-			st.KeepAlive(result)
 		})
 	})
 


### PR DESCRIPTION
To leave a note here. I had to remove the `st.SetMaxAllocs(0)` from the test. While this shouldn't in general be a problem, I find it strange that calling a function to return a Duration once you already have one will *duplicate* that object and allocate.

Not that there's a way around that (without a little bit of refactoring), as there is a conversion from `Value` to `Duration` and from `Duration` to `Value`.

One dirty way of improve things would be adding:

```go
func parseDuration(...) (starlark.Value, error) {
	if len(args) == 1 {
		if _, ok := args[0].(Duration); ok {
			return args[0], nil
		}
	}
```

at the beginning of the function. However it kind of feels strange as the "unpacking" of the arguments would be done twice (the other one during `UnpackPositionalArgs` call).

If we ever follow that route, we will be able to mark this test as `0 allocs` again, as part of the contract of the function.