### PR TITLE
Merge upstream

### DIFF
--- a/starlark/int.go
+++ b/starlark/int.go
@@ -212,6 +212,12 @@ func (i Int) Float() Float {
 			return Float(iBig.Uint64())
 		} else if iBig.IsInt64() {
 			return Float(iBig.Int64())
+		} else {
+			// Fast path for very big ints.
+			const maxFiniteLen = 1023 + 1 // max exponent value + implicit mantissa bit
+			if iBig.BitLen() > maxFiniteLen {
+				return Float(math.Inf(iBig.Sign()))
+			}
 		}
 
 		f, _ := new(big.Float).SetInt(iBig).Float64()


### PR DESCRIPTION
This PR is a follow-up for the performance improvements in `Int.Float` merged from upstream.

This PR limits the amount of memory and CPU time used during int-to-float conversion, making that function worst-case `O(1)` in both time and space.

This PR is a draft as it's waiting #160 to be merged, but it will most likely ported upstream.