### PR TITLE
Add safety flag checks to hashtable methods

### DIFF
--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -391,7 +391,10 @@ func (ht *hashtable) checkMutable(verb string) error {
 	return nil
 }
 
-func (ht *hashtable) clear() error {
+func (ht *hashtable) clear(thread *Thread) error {
+	if err := CheckSafety(thread, MemSafe|CPUSafe|IOSafe); err != nil {
+		return err
+	}
 	if err := ht.checkMutable("clear"); err != nil {
 		return err
 	}
@@ -399,6 +402,11 @@ func (ht *hashtable) clear() error {
 		return nil
 	}
 	if ht.table != nil {
+		if thread != nil {
+			if err := thread.AddExecutionSteps(int64(len(ht.table))); err != nil {
+				return err
+			}
+		}
 		for i := range ht.table {
 			ht.table[i] = bucket{}
 		}

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1761,12 +1761,7 @@ func dict_clear(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, 
 		return nil, err
 	}
 	recv := b.Receiver().(*Dict)
-	if recv.Len() > 0 {
-		if err := thread.AddExecutionSteps(int64(len(recv.ht.table))); err != nil {
-			return nil, err
-		}
-	}
-	if err := recv.Clear(); err != nil {
+	if err := recv.ht.clear(thread); err != nil {
 		return nil, err
 	}
 	return None, nil
@@ -3065,12 +3060,7 @@ func set_clear(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)
-	if recv.Len() > 0 {
-		if err := thread.AddExecutionSteps(int64(len(recv.ht.table))); err != nil {
-			return nil, err
-		}
-	}
-	if err := recv.Clear(); err != nil {
+	if err := recv.ht.clear(thread); err != nil {
 		return nil, nameErr(b, err)
 	}
 	return None, nil

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -936,7 +936,7 @@ func SafeNewDict(thread *Thread, size int) (*Dict, error) {
 	return dict, nil
 }
 
-func (d *Dict) Clear() error                                    { return d.ht.clear() }
+func (d *Dict) Clear() error                                    { return d.ht.clear(nil) }
 func (d *Dict) Delete(k Value) (v Value, found bool, err error) { return d.ht.delete(nil, k) }
 func (d *Dict) Get(k Value) (v Value, found bool, err error)    { return d.ht.lookup(nil, k) }
 func (d *Dict) Items() []Tuple                                  { return d.ht.items() }
@@ -1255,7 +1255,7 @@ func NewSet(size int) *Set {
 }
 
 func (s *Set) Delete(k Value) (found bool, err error) { _, found, err = s.ht.delete(nil, k); return }
-func (s *Set) Clear() error                           { return s.ht.clear() }
+func (s *Set) Clear() error                           { return s.ht.clear(nil) }
 func (s *Set) Has(k Value) (found bool, err error)    { _, found, err = s.ht.lookup(nil, k); return }
 func (s *Set) Insert(k Value) error                   { return s.ht.insert(nil, k, None) }
 func (s *Set) Len() int                               { return int(s.ht.len) }


### PR DESCRIPTION
This PR adds a safety flag check to the hashtable's `lookup` method, allowing other methods which trivially rely upon it to have their safeties implicitly updated as `lookup` is improved.
