### PR TITLE
Make `SafeMapping` require `Mapping`

### DIFF
--- a/starlark/value.go
+++ b/starlark/value.go
@@ -314,7 +314,7 @@ type Mapping interface {
 }
 
 type SafeMapping interface {
-	Value
+	Mapping
 	// SafeGet returns the value corresponding to the specified key,
 	// or !found if the mapping does not contain the key.
 	//


### PR DESCRIPTION
This change enforces that `SafeMapping` abides by Liskov substitution and hence that a `SafeMapping` us usable any place that a `Mapping` is too. This will benefit duck typing across places which do or do not have a thread available.
