### PR TITLE
Safely unpack Duration arguments

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -71,7 +71,7 @@ var safeties = map[string]starlark.SafetyFlags{
 	"from_timestamp":    starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
 	"is_valid_timezone": starlark.MemSafe,
 	"now":               starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
-	"parse_duration":    starlark.MemSafe | starlark.IOSafe,
+	"parse_duration":    starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
 	"parse_time":        starlark.NotSafe,
 	"time":              starlark.NotSafe,
 }
@@ -93,7 +93,7 @@ var NowFunc = time.Now
 var NowFuncSafety = starlark.MemSafe | starlark.CPUSafe
 
 func parseDuration(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	sdu := &SafeDurationUnpacker{}
+	sdu := SafeDurationUnpacker{}
 	sdu.BindThread(thread)
 	if err := starlark.UnpackPositionalArgs("parse_duration", args, kwargs, 1, &sdu); err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (d *Duration) Unpack(v starlark.Value) error {
 
 		*d = Duration(dur)
 		return nil
-	}
+	} // If more cases are added, be careful to update conversion cost computations.
 
 	return fmt.Errorf("got %s, want a duration, string, or int", v.Type())
 }

--- a/lib/time/time_test.go
+++ b/lib/time/time_test.go
@@ -223,6 +223,41 @@ func TestTimeNowAllocs(t *testing.T) {
 }
 
 func TestTimeParseDurationSteps(t *testing.T) {
+	parse_duration, ok := time.Module.Members["parse_duration"]
+	if !ok {
+		t.Fatalf("no such builtin: parse_duration")
+	}
+
+	t.Run("arg=duration", func(t *testing.T) {
+		st := startest.From(t)
+		st.RequireSafety(starlark.CPUSafe)
+		st.SetMaxExecutionSteps(0)
+		st.RunThread(func(thread *starlark.Thread) {
+			for i := 0; i < st.N; i++ {
+				_, err := starlark.Call(thread, parse_duration, starlark.Tuple{time.Duration(10)}, nil)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	})
+
+	t.Run("arg=string", func(t *testing.T) {
+		const timestamp = "10h47m"
+
+		st := startest.From(t)
+		st.RequireSafety(starlark.MemSafe)
+		st.SetMinExecutionSteps(uint64(len(timestamp)))
+		st.SetMaxExecutionSteps(uint64(len(timestamp)))
+		st.RunThread(func(thread *starlark.Thread) {
+			for i := 0; i < st.N; i++ {
+				_, err := starlark.Call(thread, parse_duration, starlark.Tuple{starlark.String(timestamp)}, nil)
+				if err != nil {
+					st.Error(err)
+				}
+			}
+		})
+	})
 }
 
 func TestTimeParseDurationAllocs(t *testing.T) {
@@ -274,9 +309,6 @@ func TestTimeTimeAllocs(t *testing.T) {
 }
 
 func TestSafeDurationUnpacker(t *testing.T) {
-	tester := starlark.NewBuiltinWithSafety("builtin", starlark.MemSafe | starlark.CPUSafe, func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error){
-	})
-
 	t.Run("duration", func(t *testing.T) {
 		st := startest.From(t)
 		st.RequireSafety(starlark.MemSafe | starlark.CPUSafe)


### PR DESCRIPTION
Unpacking arguments can take time and cause allocations, however the current API provides no way to bind this and hides the existence of this subtle problem.

This PR adds a new `SafeUnpacker` interface, `SafeUnpackArgs` and `SafeUnpackPositionalArgs` helper functions to complement the existing `Unpacker` interface, `UnpackArgs` and `UnpackPositionalArgs` helper functions.
