### PR TITLE
Mark time.{is_valid_timezone,parse_time,time} and NowFunc as IOSafe

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -69,11 +69,11 @@ var Module = &starlarkstruct.Module{
 }
 var safeties = map[string]starlark.SafetyFlags{
 	"from_timestamp":    starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
-	"is_valid_timezone": starlark.MemSafe | starlark.CPUSafe,
+	"is_valid_timezone": starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
 	"now":               starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
 	"parse_duration":    starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
-	"parse_time":        starlark.MemSafe | starlark.CPUSafe,
-	"time":              starlark.MemSafe | starlark.CPUSafe,
+	"parse_time":        starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
+	"time":              starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe,
 }
 
 func init() {
@@ -90,7 +90,7 @@ func init() {
 // so that it can be overridden, for example by applications that require their
 // Starlark scripts to be fully deterministic.
 var NowFunc = time.Now
-var NowFuncSafety = starlark.MemSafe | starlark.CPUSafe
+var NowFuncSafety = starlark.MemSafe | starlark.IOSafe | starlark.CPUSafe
 
 func parseDuration(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	sdu := SafeDurationUnpacker{}


### PR DESCRIPTION
The definition of `IOSafe` has been modified from 'free of reasonable external randomness' to 'free of access to unprotected data outside of the sandbox'. Here, as we believe timezone info will either require elevated permissions to change, or that any redirection to an alternative source will be conscious (there's a limit to how much we can protect people from themselves), the `time.*` functions which access zone info may be considered `IOSafe`
