### PR TITLE
Generalise safe binary tests

### DIFF
--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -1303,7 +1303,7 @@ type safeBinaryTest struct {
 	name              string
 	inputs            func(n int) (starlark.Value, syntax.Token, starlark.Value)
 	assertNoAllocs    bool
-	cpuSafe           bool // TODO(kcza): remove this once all binary tests are CPUSafe
+	cpuSafe           bool // TODO(kcza): remove this once all binary tests are CPUSafe.
 	minExecutionSteps uint64
 	maxExecutionSteps uint64
 }


### PR DESCRIPTION
This PR generalises the `safeBinaryAllocTest` into `safeBinaryTest`, which will also test for steps. To prevent test failures, a new field `cpuSafe bool` has been added to optionally enable step testing. Once all binary operations have been made `CPUSafe`, this will be removed.

This PR also corrects a minor receiver naming inconsistency
