### PR TITLE
Fix big int constants in tests

### DIFF
--- a/lib/json/json_test.go
+++ b/lib/json/json_test.go
@@ -94,7 +94,7 @@ func TestJsonEncodeSteps(t *testing.T) {
 	}, {
 		name:  "Int (big)",
 		input: starlark.MakeInt64(0xdeadbeef << 10),
-		steps: uint64(len(fmt.Sprintf("%d", 0xdeadbeef<<10))),
+		steps: uint64(len(fmt.Sprintf("%d", int64(0xdeadbeef<<10)))),
 	}, {
 		name:  "Float",
 		input: starlark.Float(1.4218e-1),

--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -1559,7 +1559,7 @@ func testWriteValueSteps(t *testing.T, name string, overhead uint64, shouldFail 
 	}, {
 		name:  "Int(big)",
 		input: starlark.MakeInt64(1 << 32),
-		steps: uint64(len(fmt.Sprintf("%d", 1<<32))),
+		steps: uint64(len(fmt.Sprintf("%d", int64(1<<32)))),
 	}, {
 		name: "List",
 		input: starlark.NewList([]starlark.Value{
@@ -6202,7 +6202,7 @@ func TestStringFormatSteps(t *testing.T) {
 	}, {
 		name:     "Int (big)",
 		toFormat: starlark.MakeInt64(1 << 40),
-		steps:    uint64(len(fmt.Sprintf("{%d}", 1<<40))),
+		steps:    uint64(len(fmt.Sprintf("{%d}", int64(1<<40)))),
 	}, {
 		name:     "String",
 		toFormat: starlark.String(`"test"`),


### PR DESCRIPTION
Does it make sense to add a run (even a single one on linux) for 386? This kind of problems seldom come up.