### PR TITLE
Shorten `ErrNoSuchAttr` to `ErrNoAttr`

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -650,7 +650,7 @@ type builtinMethod func(thread *starlark.Thread, b *starlark.Builtin, args starl
 func safeBuiltinAttr(thread *starlark.Thread, recv starlark.Value, name string, methods map[string]builtinMethod) (starlark.Value, error) {
 	method := methods[name]
 	if method == nil {
-		return nil, starlark.ErrNoSuchAttr
+		return nil, starlark.ErrNoAttr
 	}
 	if thread != nil {
 		if err := thread.AddAllocs(starlark.EstimateSize(&starlark.Builtin{})); err != nil {

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1036,7 +1036,7 @@ func getAttr(thread *Thread, x Value, name string, hint bool) (Value, error) {
 			}
 			attr, err = x.Attr(name)
 			if attr == nil && err == nil {
-				err = ErrNoSuchAttr
+				err = ErrNoAttr
 			}
 		}
 
@@ -1044,7 +1044,7 @@ func getAttr(thread *Thread, x Value, name string, hint bool) (Value, error) {
 			var errmsg string
 			if nsa, ok := err.(NoSuchAttrError); ok {
 				errmsg = string(nsa)
-			} else if err == ErrNoSuchAttr {
+			} else if err == ErrNoAttr {
 				errmsg = fmt.Sprintf("%s has no .%s field or method", x.Type(), name)
 			} else {
 				return nil, err // return error as is

--- a/starlark/interp_test.go
+++ b/starlark/interp_test.go
@@ -384,7 +384,7 @@ func (utsf *unsafeTestSetField) Hash() (uint32, error) {
 }
 
 func (utsf *unsafeTestSetField) Attr(name string) (starlark.Value, error) {
-	return nil, starlark.ErrNoSuchAttr
+	return nil, starlark.ErrNoAttr
 }
 
 func (utsf *unsafeTestSetField) SetField(name string, val starlark.Value) error {
@@ -409,7 +409,7 @@ func (tsf *testSetField) Hash() (uint32, error) {
 }
 
 func (tsf *testSetField) Attr(name string) (starlark.Value, error) {
-	return nil, starlark.ErrNoSuchAttr
+	return nil, starlark.ErrNoAttr
 
 }
 func (tsf *testSetField) SetField(name string, val starlark.Value) error {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -35,7 +35,7 @@ var Universe StringDict
 var universeSafeties map[string]SafetyFlags
 
 var ErrUnsupported = errors.New("unsupported operation")
-var ErrNoSuchAttr = errors.New("no such attribute")
+var ErrNoAttr = errors.New("no such attribute")
 
 func init() {
 	// https://github.com/google/starlark-go/blob/master/doc/spec.md#built-in-constants-and-functions
@@ -316,7 +316,7 @@ func safeBuiltinAttr(thread *Thread, recv Value, name string, methods map[string
 	}
 	b := methods[name]
 	if b == nil {
-		return nil, ErrNoSuchAttr
+		return nil, ErrNoAttr
 	}
 	if thread != nil {
 		if err := thread.AddAllocs(EstimateSize(&Builtin{})); err != nil {
@@ -762,7 +762,7 @@ func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 	if object, ok := object.(HasAttrs); ok {
 		if object2, ok := object.(HasSafeAttrs); ok {
-			if _, err := object2.SafeAttr(thread, name); err == ErrNoSuchAttr {
+			if _, err := object2.SafeAttr(thread, name); err == ErrNoAttr {
 				return False, nil
 			} else if _, ok := err.(NoSuchAttrError); ok {
 				return False, nil

--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -2304,7 +2304,7 @@ func TestGetattrSteps(t *testing.T) {
 			safety: starlark.NotSafe,
 			attr: func(thread *starlark.Thread, s string) (starlark.Value, error) {
 				t.Error("SafeAttr called")
-				return nil, starlark.ErrNoSuchAttr
+				return nil, starlark.ErrNoAttr
 			},
 		}
 		_, err := starlark.Call(thread, getattr, starlark.Tuple{value, starlark.String("test")}, nil)
@@ -2396,7 +2396,7 @@ func TestGetattrAllocs(t *testing.T) {
 			safety: starlark.NotSafe,
 			attr: func(thread *starlark.Thread, s string) (starlark.Value, error) {
 				t.Error("SafeAttr called")
-				return nil, starlark.ErrNoSuchAttr
+				return nil, starlark.ErrNoAttr
 			},
 		}
 		_, err := starlark.Call(thread, getattr, starlark.Tuple{input, starlark.String("test")}, nil)
@@ -2614,7 +2614,7 @@ func TestHasattrAllocs(t *testing.T) {
 			safety: starlark.NotSafe,
 			attr: func(thread *starlark.Thread, s string) (starlark.Value, error) {
 				t.Error("SafeAttr called")
-				return nil, starlark.ErrNoSuchAttr
+				return nil, starlark.ErrNoAttr
 			},
 		}
 		_, err := starlark.Call(thread, hasattr, starlark.Tuple{input, starlark.String("test")}, nil)

--- a/starlarkstruct/module.go
+++ b/starlarkstruct/module.go
@@ -42,7 +42,7 @@ func (m *Module) SafeAttr(thread *starlark.Thread, name string) (starlark.Value,
 	}
 	member, ok := m.Members[name]
 	if !ok {
-		return nil, starlark.ErrNoSuchAttr
+		return nil, starlark.ErrNoAttr
 	}
 	return member, nil
 }


### PR DESCRIPTION
This change brings this error name into line with standard Go practice
