### PR TITLE
Guard against overflowing runtime.roundupsize calls

### DIFF
--- a/starlark/estimatesize.go
+++ b/starlark/estimatesize.go
@@ -405,6 +405,8 @@ func roundAllocSize(size int64) int64 {
 		return 0
 	} else if size < tinyAllocMaxSize {
 		return tinyAllocMaxSize
+	} else if size == math.MaxInt64 {
+		return math.MaxInt64
 	} else if rounded := roundupsize(uintptr(size)); rounded > maxSafeUintptr {
 		return math.MaxInt64
 	} else {


### PR DESCRIPTION
It may become possible in future for `roundupsize` to overflow if given a sufficiently large value. Although this is not the case at the moment, this PR puts a guard in place as we rely on an internal function here and hence have no contract.
