### PR TITLE
Avoid resource overflows in tests

### DIFF
--- a/starlark/allocation_test.go
+++ b/starlark/allocation_test.go
@@ -64,7 +64,7 @@ func TestAllocDeclAndCheckBoundary(t *testing.T) {
 
 	if err := thread.CheckAllocs(allocCap); err != nil {
 		t.Errorf("unexpected error: %v", err)
-	} else if err := thread.CheckAllocs(allocCap + 1); err == nil {
+	} else if err := thread.CheckAllocs(starlark.SafeAdd64(allocCap, 1)); err == nil {
 		t.Errorf("expected error checking too-many allocations")
 	}
 
@@ -72,7 +72,7 @@ func TestAllocDeclAndCheckBoundary(t *testing.T) {
 		t.Errorf("could not allocate entire quota: %v", err)
 	} else {
 		thread.AddAllocs(-allocCap)
-		if err := thread.AddAllocs(allocCap + 1); err == nil {
+		if err := thread.AddAllocs(starlark.SafeAdd64(allocCap, 1)); err == nil {
 			t.Errorf("expected error when exceeding quota")
 		}
 	}

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -1644,7 +1644,10 @@ func TestSafeBinary(t *testing.T) {
 	}
 	makeString := func(thread *starlark.Thread, n int) (starlark.Value, error) {
 		if thread != nil {
-			resultSize := starlark.EstimateMakeSize([]byte{}, n) + starlark.StringTypeOverhead
+			resultSize := starlark.SafeAdd64(
+				starlark.EstimateMakeSize([]byte{}, n),
+				starlark.StringTypeOverhead,
+			)
 			if err := thread.AddAllocs(resultSize); err != nil {
 				return nil, err
 			}
@@ -1687,8 +1690,10 @@ func TestSafeBinary(t *testing.T) {
 	}
 	makeTuple := func(thread *starlark.Thread, n int) (starlark.Value, error) {
 		if thread != nil {
-			resultSize := starlark.EstimateMakeSize([]starlark.Value{}, n) +
-				starlark.EstimateSize(&starlark.List{})
+			resultSize := starlark.SafeAdd64(
+				starlark.EstimateMakeSize([]starlark.Value{}, n),
+				starlark.EstimateSize(&starlark.List{}),
+			)
 			if err := thread.AddAllocs(resultSize); err != nil {
 				return nil, err
 			}
@@ -2077,8 +2082,10 @@ func TestSafeBinary(t *testing.T) {
 			left: func(thread *starlark.Thread, n int) (starlark.Value, error) {
 				const format = "%(k)r"
 				if thread != nil {
-					resultSize := starlark.EstimateMakeSize([]byte{}, len(format)*n) +
-						starlark.StringTypeOverhead
+					resultSize := starlark.SafeAdd64(
+						starlark.EstimateMakeSize([]byte{}, len(format)*n),
+						starlark.StringTypeOverhead,
+					)
 					if err := thread.AddAllocs(resultSize); err != nil {
 						return nil, err
 					}

--- a/starlark/library_test.go
+++ b/starlark/library_test.go
@@ -503,8 +503,10 @@ func TestAnyAllocs(t *testing.T) {
 			args := starlark.Tuple{&testIterable{
 				maxN: st.N,
 				nth: func(thread *starlark.Thread, n int) (starlark.Value, error) {
-					overheadSize := starlark.EstimateMakeSize([]starlark.Value{}, 16) +
-						starlark.EstimateSize(starlark.List{})
+					overheadSize := starlark.SafeAdd64(
+						starlark.EstimateMakeSize([]starlark.Value{}, 16),
+						starlark.EstimateSize(starlark.List{}),
+					)
 					if err := thread.AddAllocs(overheadSize); err != nil {
 						return nil, err
 					}
@@ -2451,8 +2453,10 @@ func TestGetattrAllocs(t *testing.T) {
 			safety: starlark.Safe,
 			attr: func(thread *starlark.Thread, attr string) (starlark.Value, error) {
 				const repetitions = 5
-				resultSize := starlark.EstimateMakeSize([]byte{}, len(attr)*repetitions) +
-					starlark.StringTypeOverhead
+				resultSize := starlark.SafeAdd64(
+					starlark.EstimateMakeSize([]byte{}, len(attr)*repetitions),
+					starlark.StringTypeOverhead,
+				)
 				if err := thread.AddAllocs(resultSize); err != nil {
 					return nil, err
 				}
@@ -3741,8 +3745,10 @@ func TestReversedAllocs(t *testing.T) {
 		st.RequireSafety(starlark.MemSafe)
 		st.RunThread(func(thread *starlark.Thread) {
 			const tupleCount = 100
-			itemSize := starlark.EstimateMakeSize(starlark.Tuple{}, tupleCount) +
-				starlark.EstimateSize(starlark.Tuple{})
+			itemSize := starlark.SafeAdd64(
+				starlark.EstimateMakeSize(starlark.Tuple{}, tupleCount),
+				starlark.EstimateSize(starlark.Tuple{}),
+			)
 			iter := &testIterable{
 				maxN: 10,
 				nth: func(thread *starlark.Thread, _ int) (starlark.Value, error) {
@@ -6694,8 +6700,10 @@ func TestListExtendAllocs(t *testing.T) {
 		st.RunThread(func(thread *starlark.Thread) {
 			iter := &testIterable{
 				nth: func(thread *starlark.Thread, _ int) (starlark.Value, error) {
-					resultSize := starlark.EstimateSize(&starlark.List{}) +
-						starlark.EstimateMakeSize([]starlark.Value{}, 16)
+					resultSize := starlark.SafeAdd64(
+						starlark.EstimateSize(&starlark.List{}),
+						starlark.EstimateMakeSize([]starlark.Value{}, 16),
+					)
 					if err := thread.AddAllocs(resultSize); err != nil {
 						return nil, err
 					}
@@ -6737,8 +6745,10 @@ func TestListExtendAllocs(t *testing.T) {
 			}
 			iter := &testIterable{
 				nth: func(thread *starlark.Thread, _ int) (starlark.Value, error) {
-					resultSize := starlark.EstimateSize(&starlark.List{}) +
-						starlark.EstimateMakeSize([]starlark.Value{}, 16)
+					resultSize := starlark.SafeAdd64(
+						starlark.EstimateSize(&starlark.List{}),
+						starlark.EstimateMakeSize([]starlark.Value{}, 16),
+					)
 					if err := thread.AddAllocs(resultSize); err != nil {
 						return nil, err
 					}
@@ -11376,7 +11386,10 @@ func TestSafeIterateAllocs(t *testing.T) {
 		st.RunThread(func(thread *starlark.Thread) {
 			allocating := &testIterable{
 				nth: func(thread *starlark.Thread, n int) (starlark.Value, error) {
-					tupleSize := starlark.EstimateMakeSize(starlark.Tuple{}, 16) + starlark.SliceTypeOverhead
+					tupleSize := starlark.SafeAdd64(
+						starlark.EstimateMakeSize(starlark.Tuple{}, 16),
+						starlark.SliceTypeOverhead,
+					)
 					if err := thread.AddAllocs(tupleSize); err != nil {
 						return nil, err
 					}

--- a/startest/startest_test.go
+++ b/startest/startest_test.go
@@ -880,8 +880,10 @@ func (iter *dummyRangeIterator) Err() error { return nil }
 
 func TestRunStringMemSafety(t *testing.T) {
 	t.Run("safety=safe", func(t *testing.T) {
-		allocateResultSize := starlark.EstimateSize(starlark.Tuple{}) +
-			starlark.EstimateMakeSize(starlark.Tuple{}, 100)
+		allocateResultSize := starlark.SafeAdd64(
+			starlark.EstimateSize(starlark.Tuple{}),
+			starlark.EstimateMakeSize(starlark.Tuple{}, 100),
+		)
 		allocate := starlark.NewBuiltinWithSafety("allocate", startest.STSafe, func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 			if err := thread.AddAllocs(allocateResultSize); err != nil {
 				return nil, err


### PR DESCRIPTION
This PR enforces the convention of using safe arithmetic when handling resource counts. No test here is expected to overflow; the purpose of this PR is to encourage future readers to adopt safe practices
