### PR TITLE
Test resource declarations and checks with invalid delta

### DIFF
--- a/starlark/allocation_test.go
+++ b/starlark/allocation_test.go
@@ -231,6 +231,7 @@ func TestOverzealousNegativeDeltaDeclaration(t *testing.T) {
 
 func TestInvalidDeltaAllocs(t *testing.T) {
 	thread := &starlark.Thread{}
+	thread.SetMaxAllocs(math.MaxInt64)
 	if err := thread.CheckAllocs(starlark.InvalidSafeInt); err == nil {
 		t.Errorf("expected an error when checking invalid number of allocs: got nil")
 	}

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -1515,6 +1515,7 @@ func TestCheckSteps(t *testing.T) {
 
 func TestInvalidDeltaSteps(t *testing.T) {
 	thread := &starlark.Thread{}
+	thread.SetMaxSteps(math.MaxInt64)
 	if err := thread.CheckSteps(starlark.InvalidSafeInt); err == nil {
 		t.Errorf("expected an error when checking invalid number of steps: got nil")
 	}


### PR DESCRIPTION
This PR adds missing tests for:
- `thread.AddAllocs(invalid)`
- `thread.AddSteps(invalid)`
- `thread.CheckAllocs(invalid)`
- `thread.CheckSteps(invalid)`
