### PR TITLE
docs: correct the package location in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ When you have finished, type `Ctrl-D` to close the REPL's input stream.
 Embed the interpreter in your Go program:
 
 ```go
-import "github.com/canonical/starlark"
+import "github.com/canonical/starlark/starlark"
 
 // Execute Starlark program in a file.
 thread := &starlark.Thread{Name: "my thread"}


### PR DESCRIPTION
Adjust the import in the README example from `canonical/starlark` to `canonical/starlark/starlark`. This seems to be the correct package for the example.