### PR TITLE
fix: installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Build the code:
 ```shell
 # check out the code and dependencies,
 # and install interpreter in $GOPATH/bin
-$ go install github.com/canonical/starlark@latest
+$ go install github.com/canonical/starlark/cmd/starlark@latest
 ```
 <!-- TODO(kcza): update the package version above -->
 


### PR DESCRIPTION
The current installation instruction doesn't work (at least for me):

```shell
$ go install github.com/canonical/starlark@latest
go: github.com/canonical/starlark@latest: module github.com/canonical/starlark@latest found (v0.0.0-20250411183636-e4fd77751876), but does not contain package github.com/canonical/starlark
```
