### PR TITLE
enhancement: tiobe workflow hardening

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+# separated from the Tiobe workflow to prevent building/running
+# untrusted code within the repo, e.g. running `go test` in
+# pull_request_target
+
+# completion of this workflow triggers the tiobe workflow, which
+# executes with access to secrets, but does NOT run the code 
+# associated with the pull request
+
+name: Coverage
+on:
+  pull_request:
+    branches: 
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Test TICS daily
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+
+      - name: Setup dependencies
+        run: |
+          go install github.com/axw/gocov/gocov@latest
+          go install github.com/AlekSi/gocov-xml@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Test
+        run: |
+          go test -v -p 1 -coverprofile=coverage.out ./...
+
+      - name: Convert coverage files
+        run: |
+          mkdir -p cover
+          gocov convert coverage.out > cover/coverage.json
+          gocov-xml < cover/coverage.json > cover/coverage-go.xml
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: coverage
+          path: cover/

--- a/.github/workflows/tiobe.yml
+++ b/.github/workflows/tiobe.yml
@@ -1,50 +1,30 @@
 name: Tiobe TICS
 on:
-  # Running on pull_request_target instead of pull_request because this workflow
-  # uses secrets, and thus we need to ensure it runs under this project's code base.
-  pull_request_target:
-    branches: 
-      - main
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'  # Test TICS daily
+  workflow_run:
+    workflows: ["Coverage"]
+    types:
+      - completed
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  actions: read
 
 jobs:
   tics:
     name: Tiobe TICS
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.head_ref || '' }}
-          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || '' }}
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Install Go
-        uses: actions/setup-go@v5
-
-      - name: Setup dependencies
-        run: |
-          go install github.com/axw/gocov/gocov@latest
-          go install github.com/AlekSi/gocov-xml@latest
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-
-      - name: Test
-        run: |
-          go test -v -p 1 -coverprofile=coverage.out ./...
-      
-      - name: Convert coverage files
-        run: |
-          mkdir -p cover
-          gocov convert coverage.out > cover/coverage.json
-          gocov-xml < cover/coverage.json > cover/coverage-go.xml
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: coverage
+          path: cover/
 
       - name: Run TiCS client analysis
         uses: tiobe/tics-github-action@v3


### PR DESCRIPTION
Separates the coverage and tiobe workflows

Separation allows the insecure `coverage` workflow to execute within `pull_request` instead of `pull_request_target`. The required artifacts are uploaded.

The `tiobe` workflow is triggered by the completion of the `coverage` workflow and runs with access to repo secrets. It does not run the code associated with the pull request. It downloads the generated artifacts for reporting.

(I am assuming that the tiobe workflow requires both the coverage files and a checked-out copy of the code; If either could be dropped, the workflows could be simplified and further secured.)