### PR TITLE
Add workshop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.workshop.lock

--- a/.workshop/starlark-dev.yaml
+++ b/.workshop/starlark-dev.yaml
@@ -1,0 +1,12 @@
+name: starlark-dev
+base: ubuntu@24.04
+connections:
+  - plug: omp:omp-home
+    slot: system:mount
+sdks:
+  - name: direnvrc
+  - name: go
+  - name: omp
+actions:
+  omp: direnv exec /project omp "$@"
+  go: direnv exec /project go "$@"


### PR DESCRIPTION
This PR adds a workshop dev environment to this project. Notable inclusions of this PR:

- The `go` sdk is added
- The `omp` sdk is added to enable agentic workflows with this project
- The `direnvrc` sdk is added to improve ergonomics when handling flags. This is useful for `omp` to relax timeouts (a little problematic when using large local models), it is applied to the `go` action also for consistency.
- The `omp:omp-home` plug is exposed to allow users to bring their own API keys
